### PR TITLE
Fix typo in generar script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "generar": "node -r dotenv/config index.js",
     "generar-vep": "node -r dotenv/config generar-vep.js",
-    "consultar": "node -r dotenv/config consulta.js"
+    "consultar": "node -r dotenv/config consultar.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Si se quiere usar el script para consultar ahora no funciona porque le fatla una r.
![image](https://user-images.githubusercontent.com/5702873/185226937-46ce5ae8-861c-4d53-89e7-253cb6cd6a2a.png)
