### PR TITLE
Agregar consulta de facturacion anualizada

### DIFF
--- a/consultar-anualizado.js
+++ b/consultar-anualizado.js
@@ -1,0 +1,101 @@
+// npm install playwright
+// may take a while for downloading binaries
+// minimum node version 8 for async / await feature
+const {
+  login,
+  rounder,
+  sanitizeNumber,
+  getFormatedDate,
+  getDatesfromOneYearBack,
+} = require('./helper.js')
+
+const playwright = require('playwright')
+const uuid = require('uuid')
+
+async function main() {
+  // disable headless to see the browser's action
+  const browser = await playwright.chromium.launch({
+    headless: false,
+    args: ['--disable-dev-shm-usage'],
+  })
+  const context = await browser.newContext({ acceptDownloads: true })
+  const page = await context.newPage()
+
+  const navigationPromise = page.waitForNavigation({
+    waitUntil: 'domcontentloaded',
+  })
+
+  await login(page)
+
+  await page.click('text=Mis Comprobantes')
+  await page.waitForTimeout(1000)
+
+  let pages = await context.pages()
+  await page.waitForTimeout(1000)
+  const facturadorPage = pages[1]
+  await page.waitForTimeout(1000)
+
+  // Acceder a Consultas
+  try {
+    await navigationPromise
+    await facturadorPage.waitForTimeout(2000)
+  } catch (error) {
+    console.log('Sitio de la afip lento. Reintentar.')
+    throw error
+  }
+  await facturadorPage.click('text=Emitidos')
+  await facturadorPage.waitForTimeout(1000)
+
+  await facturadorPage.selectOption('select[id="tipoComprobante"]', '11')
+  await facturadorPage.waitForTimeout(1000)
+
+  await facturadorPage.click('id=btnMostrarPuntosVentas')
+  await facturadorPage.waitForTimeout(1000)
+
+  await facturadorPage.selectOption('select[id="listaPuntosVentaModal"]', '00001')
+  await facturadorPage.waitForTimeout(1000)
+
+  await facturadorPage.click('id=btnAceptarModal')
+  await facturadorPage.waitForTimeout(1000)
+
+  //REPETIR POR CADA FECHA
+  var datesArr = getDatesfromOneYearBack()
+  let totalAnual = 0
+  // datesArr.forEach(async e => {
+  for (const e of datesArr) {
+    await facturadorPage.click('input[id="fechaEmision"]')
+    await facturadorPage.waitForTimeout(1000)
+    await facturadorPage.type('input[name="daterangepicker_start"]', getFormatedDate(e.from))
+    await facturadorPage.waitForTimeout(1000)
+    await facturadorPage.type('input[name="daterangepicker_end"]', getFormatedDate(e.to))
+    await facturadorPage.waitForTimeout(1000)
+    await facturadorPage.click('text=Aplicar')
+    await facturadorPage.waitForTimeout(1000)
+
+    await facturadorPage.click('text=Buscar')
+    await facturadorPage.waitForTimeout(1000)
+  
+    // Cambiar cantidad de items a 50 en la tabla (MEJORAR)
+    await facturadorPage.click('button.buttons-collection.buttons-page-length')
+    await facturadorPage.waitForTimeout(1000)
+    await facturadorPage.locator('li.button-page-length').nth(3).click()
+    await facturadorPage.waitForTimeout(1000)
+  
+    const rows = await facturadorPage.locator(
+      'table#tablaDataTables tr td.alignRight'
+    )
+    const count = await rows.count()
+    for (let i = 0; i < count; ++i) {
+      totalAnual += sanitizeNumber(await rows.nth(i).textContent())
+    }
+    await facturadorPage.click('text=Consulta')
+    await facturadorPage.waitForTimeout(1000)
+  }
+
+  console.log(`Total facturado desde ${datesArr[0].from} hasta ${datesArr.slice(-1)[0].to}: $${totalAnual}`)
+
+  // ToDo downgrade next timeout
+  await facturadorPage.waitForTimeout(10000)
+  await browser.close()
+}
+main()

--- a/helper.js
+++ b/helper.js
@@ -28,6 +28,59 @@ const dateFormatted = () =>
     today.getMonth() + 1
   )}/${today.getFullYear()}`
 
+
+// Dado '$ 20.000,00' devuelve 20000
+const sanitizeNumber = (number) => {
+  let result = number.split('$')[1].trim()
+  result = parseInt(result.split(',')[0].replace('.', ''))
+  return result
+}
+
+const getFormatedDate = (myDate) => {
+  // returns DD/MM/YYYY
+  var day = myDate.getDate();
+  var month = myDate.getMonth() + 1;
+  var year = myDate.getFullYear();
+
+  if (day < 10) { day = '0' + day; }
+  if (month < 10) { month = '0' + month; }
+
+  return `${day}/${month}/${year}`;
+}
+
+const subtractYears = (numOfYears, date = new Date()) => {
+  return new Date(date.setFullYear(date.getFullYear() - numOfYears));
+}
+
+const addDays = (date, numOfDays) => {
+  var myDate = new Date(date);
+  return new Date(myDate.setDate(myDate.getDate() + numOfDays));
+}
+
+/**
+ * Devuelve array de fechas de 27 días empezando de 1 año atrás desde hoy.
+ * Ej: { from: 2021-10-31T01:34:49.818Z, to: 2021-11-27T01:34:49.818Z }
+ * @returns Array
+ */
+const getDatesfromOneYearBack = () => {
+  var minus1year = subtractYears(1);
+  var sumDate    = addDays(minus1year, 27);
+  var datesArr   = []
+
+  for (let i = 0; i < 13; i++) {
+    var dateObj = { 'from': sumDate }
+    sumDate = addDays(sumDate, 27);
+    if(sumDate > today){
+      dateObj.to = today;
+      datesArr.push(dateObj);
+      break
+    }
+    dateObj.to = sumDate;
+    datesArr.push(dateObj);
+  }
+  return datesArr;
+}
+
 /**
  * Autentica en la pagina del afip completando user and password
  * Usa las credenciales de .env
@@ -85,4 +138,10 @@ module.exports = {
   saveToCSV,
   dateAsString,
   dateFormatted,
+  sanitizeNumber,
+  getFormatedDate,
+  subtractYears,
+  addDays,
+  today,
+  getDatesfromOneYearBack,
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generar": "node -r dotenv/config index.js",
     "generar-vep": "node -r dotenv/config generar-vep.js",
     "consultar": "node -r dotenv/config consultar.js",
+    "consultar-anual": "node -r dotenv/config consultar-anualizado.js",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "lint:check": "eslint .",


### PR DESCRIPTION
Mañana agrego pantallas y mas detalle.

- Para saber si estamos cerca del limite necesitamos sumarizar las facturas desde hoy 1 año para atrás.
- Dado que es un embole ir seleccionando de a 31 días, agregue este script que hace la suma.
- Dada la fecha de hoy va un año para atrás, guarda desde/hasta en períodos de a 27 días y va sumando el listado.
- La única parte fea es que si un mes hay más de 50 facturas explota.


**TESTEAR**
`npm run consultar-anual`